### PR TITLE
Removing blockedAutoColorItems=AnyDesk,Nextcloud and notification area tweaks.

### DIFF
--- a/usr/share/biglinux/kdebiglinux/nextg/latte/Default.layout.latte
+++ b/usr/share/biglinux/kdebiglinux/nextg/latte/Default.layout.latte
@@ -1001,12 +1001,11 @@ DialogWidth=1920
 PreloadWeight=26
 
 [Containments][17][General]
-blockedAutoColorItems=AnyDesk,Nextcloud
+canFillThickness=true
 extraItems=org.kde.kdeconnect,org.kde.plasma.battery,org.kde.plasma.bluetooth,org.kde.plasma.devicenotifier,org.kde.plasma.keyboardindicator,org.kde.plasma.mediacontroller,org.kde.plasma.networkmanagement,org.kde.plasma.notifications,org.kde.plasma.volume,org.kde.plasma.clipboard,org.kde.plasma.nightcolorcontrol,org.kde.plasma.manage-inputmethod,touchpad,org.kde.plasma.keyboardlayout,org.kde.kscreen,org.kde.plasma.printmanager
 hiddenItems=Plasma,org.kde.plasma.manage-inputmethod,touchpad
-iconsSpacing=5
+iconsSpacing=9
 knownItems=org.kde.kdeconnect,org.kde.plasma.battery,org.kde.plasma.bluetooth,org.kde.plasma.clipboard,org.kde.plasma.devicenotifier,org.kde.plasma.keyboardindicator,org.kde.plasma.keyboardlayout,org.kde.plasma.mediacontroller,org.kde.plasma.networkmanagement,org.kde.plasma.nightcolorcontrol,org.kde.plasma.notifications,org.kde.plasma.volume,org.kde.plasma.manage-inputmethod,org.kde.plasma.printmanager
-scaleIconsToFit=true
 shownItems=org.kde.plasma.volume,org.kde.plasma.clipboard,org.kde.plasma.networkmanagement
 
 [Containments][18]


### PR DESCRIPTION
Removing blockedAutoColorItems=AnyDesk,Nextcloud and notification area tweaks.

Changed: "Panel icon size" to small with 9 spacing and "Behavior" Fill enabled.