### PR TITLE
fix: unset SDL_VIDEODRIVER due to some games needing other SDL driver…

### DIFF
--- a/usr/bin/startkde-biglinux
+++ b/usr/bin/startkde-biglinux
@@ -29,7 +29,6 @@ if [ "$1" = "wayland" ]; then
     [[ -z $QT_SCALE_FACTOR_ROUNDING_POLICY ]] && export QT_SCALE_FACTOR_ROUNDING_POLICY=RoundPreferFloor
 
     [[ -z $ELECTRON_OZONE_PLATFORM_HINT ]] && export ELECTRON_OZONE_PLATFORM_HINT=auto
-    [[ -z $SDL_VIDEODRIVER ]] && export SDL_VIDEODRIVER=wayland
     [[ -z $MOZ_ENABLE_WAYLAND ]] && export MOZ_ENABLE_WAYLAND=1
     [[ -z $KWIN_EFFECTS_FORCE_ANIMATIONS ]] && export KWIN_EFFECTS_FORCE_ANIMATIONS=1
 


### PR DESCRIPTION
Remove a definição da variável `SDL_VIDEODRIVER` com o conteúdo `wayland`. Alguns jogos testados, dentre eles alguns com EAC como o Dead By Daylight não estavam funcionando no Wayland por conta dessa variável definida.
Outras variantes do BigLinux como as Community com GNOME e Cinnamon não tinham nenhum problema para rodar o jogo em Wayland já que essa variável não existia. Outras distros testadas com Pasma como Fedora e Arch, também não definem essa invariável.

https://wiki.archlinux.org/title/Wayland#SDL2
https://wiki.libsdl.org/SDL2/FAQUsingSDL#how_do_i_choose_a_specific_audio_driver
https://www.reddit.com/r/linux_gaming/comments/1cvrvyg/psa_easy_anticheat_eac_failed_to_initialize/